### PR TITLE
Fix CAP code collection parsing

### DIFF
--- a/src/CAPNet.Tests/Resources/AllElementsFilledAlert.xml
+++ b/src/CAPNet.Tests/Resources/AllElementsFilledAlert.xml
@@ -9,7 +9,8 @@
   <scope>Public</scope>
   <restriction>restriction</restriction>
   <addresses>"address 1" address2 " address 3" address4</addresses>
-  <code>code</code>
+  <code>code1</code>
+  <code>code2</code>
   <note>note</note>
   <references>reference1 reference2 reference3</references>
   <incidents>incident1 "very bad incident" "very very bad  incident "</incidents>

--- a/src/CAPNet.Tests/Resources/MultipleAlertXml.xml
+++ b/src/CAPNet.Tests/Resources/MultipleAlertXml.xml
@@ -10,6 +10,7 @@
   <restriction>restriction</restriction>
   <addresses>"address 1" address2 " address 3" address4</addresses>
   <code>code</code>
+  <code>code2</code>
   <note>note</note>
   <references>references reference2</references>
   <incidents>" incident0" incident1 incident2 "bad incident" "another bad incident"</incidents>

--- a/src/CAPNet.Tests/XmlCreatorTests.cs
+++ b/src/CAPNet.Tests/XmlCreatorTests.cs
@@ -130,11 +130,15 @@ namespace CAPNet.Tests
                 //   <note>note</note>
                 Note = "note",
                 //   <references>references</references>
-                
+
             };
 
             //<code>code</code>
             orangeAlert.Codes.Add("code");
+
+            //<code>code2</code>
+            orangeAlert.Codes.Add("code2");
+
             //<references>references reference2</references>
             orangeAlert.References.Add("references");
             orangeAlert.References.Add("reference2");

--- a/src/CAPNet.Tests/XmlCreatorTests.cs
+++ b/src/CAPNet.Tests/XmlCreatorTests.cs
@@ -127,14 +127,14 @@ namespace CAPNet.Tests
                 Source = "source",
                 //   <restriction>restriction</restriction>
                 Restriction = "restriction",
-                //   <code>code</code>
-                Code = "code",
                 //   <note>note</note>
                 Note = "note",
                 //   <references>references</references>
                 
             };
 
+            //<code>code</code>
+            orangeAlert.Codes.Add("code");
             //<references>references reference2</references>
             orangeAlert.References.Add("references");
             orangeAlert.References.Add("reference2");

--- a/src/CAPNet/Models/Alert.cs
+++ b/src/CAPNet/Models/Alert.cs
@@ -17,6 +17,7 @@ namespace CAPNet.Models
             addresses = new List<string>();
             incidents = new List<string>();
             references = new List<string>();
+            Codes = new List<string>();
         }
 
         /// <summary>
@@ -207,7 +208,7 @@ namespace CAPNet.Models
         ///     </item>
         ///   </list>
         /// </remarks>
-        public string Code { get; set; }
+        public ICollection<string> Codes { get; }
 
         /// <summary>
         /// The text describing the purpose or significance of the alert message 

--- a/src/CAPNet/XmlCreator.cs
+++ b/src/CAPNet/XmlCreator.cs
@@ -53,7 +53,7 @@ namespace CAPNet
             AddElementIfHasContent(alertElement, "restriction", alert.Restriction);
             string addressesContent = alert.Addresses.ElementsDelimitedBySpace();
             AddElementIfHasContent(alertElement, "addresses", addressesContent);
-            AddElementIfHasContent(alertElement, "code", alert.Code);
+            alertElement.Add(alert.Codes.Select(code => new XElement(CAP12Namespace + "code", code)));
             AddElementIfHasContent(alertElement, "note", alert.Note);
             string referencesContent = alert.References.ElementsDelimitedBySpace();
             AddElementIfHasContent(alertElement, "references", referencesContent);

--- a/src/CAPNet/XmlParser.cs
+++ b/src/CAPNet/XmlParser.cs
@@ -84,11 +84,12 @@ namespace CAPNet
                 alert.Note = noteNode.Value;
             }
 
-            var codeNode = alertElement.Element(capNamespace + "code");
-            if (codeNode != null)
-            {
-                alert.Code = codeNode.Value;
-            }
+            var codeNodes = alertElement.Elements(capNamespace + "code");
+            var codes = from codeNode in codeNodes
+                        where codeNode != null
+                        select codeNode.Value;
+
+            alert.Codes.AddRange(codes);
 
             var addressesNode = alertElement.Element(capNamespace + "addresses");
             var addressNodeValue = addressesNode?.Value;

--- a/src/EDXLNet.Tests/EdxlDeXmlCreatorTests.cs
+++ b/src/EDXLNet.Tests/EdxlDeXmlCreatorTests.cs
@@ -10,7 +10,8 @@ namespace EDXLNet.Tests
         public void CanCreateXElementFromEdxlDistribution()
         {
             var alert1 = new Alert { Identifier = "Alert1" };
-            var alert2 = new Alert { Identifier = "Alert2", Code = "Secret" };
+            var alert2 = new Alert { Identifier = "Alert2" };
+            alert2.Codes.Add("Secret");
 
             var edxlDistribution = new EdxlDistribution
             {


### PR DESCRIPTION
According to CAP, the 'code' field should be a collection, not a single field. I've changed it to a collection and implemented parsing of it.